### PR TITLE
Fixed display issues on mobile browser

### DIFF
--- a/app.R
+++ b/app.R
@@ -142,7 +142,7 @@ server <- function(input, output) {
 
   output$plot1 <- renderPlot({
 
-    pnt_size = 5
+    pnt_size = 3.5
     ggplot(df$infections) +
       geom_point(aes(x = X, y = Y, col = quarantined),
                  shape = 15, size = pnt_size + 2) +

--- a/app.R
+++ b/app.R
@@ -160,7 +160,9 @@ server <- function(input, output) {
       theme_minimal() +
       theme(axis.text = element_blank(),
             axis.title = element_blank(),
-            legend.title = element_blank()) +
+            legend.title = element_blank(),
+            legend.position = "bottom",
+            legend.box = "vertical") +
       ggtitle(paste("Days: ", counter$countervalue,
                     " Shown: ", game_summary$num_I_shown,
                     " Quarantined: ", game_summary$num_I_shown,


### PR DESCRIPTION
I think the display issues in #1 occur because the legends on the right take up too much space. A simple fix would be to move the legends to the bottom. 

Suggested change:
<img src="https://user-images.githubusercontent.com/12783172/78384242-8a09ff80-7625-11ea-9116-d33d6026b0b8.png" width="50%" height="50%" />